### PR TITLE
deprecated jnlp image name

### DIFF
--- a/jenkins-gke/jenkins-helm/values.yaml
+++ b/jenkins-gke/jenkins-helm/values.yaml
@@ -75,7 +75,7 @@ master:
                               label: "jnlp-exec"
                               containers:
                                 - name: "jnlp"
-                                  image: "jenkinsci/jnlp-slave"
+                                  image: "jenkins/jnlp-slave"
                                   alwaysPullImage: false
                                   workingDir: "/home/jenkins/agent"
                                   ttyEnabled: true


### PR DESCRIPTION
jenkinsci/jnlp-slave image name is deprecated, using jenkins/jnlp-slave.
https://github.com/jenkinsci/docker-jnlp-slave