### PR TITLE
Change of hosted URL for help charts.

### DIFF
--- a/jenkins-gke/tf-gke/main.tf
+++ b/jenkins-gke/tf-gke/main.tf
@@ -188,7 +188,7 @@ data "local_file" "helm_chart_values" {
 
 resource "helm_release" "jenkins" {
   name       = "jenkins"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
+  repository = "https://charts.helm.sh/stable"
   chart      = "jenkins"
   version    = "1.9.18"
   timeout    = 1200


### PR DESCRIPTION
The new location is updated as per information available on this link https://helm.sh/blog/new-location-stable-incubator-charts/